### PR TITLE
[ linter ] warning about empty where clauses

### DIFF
--- a/SRC/Lnt.hs
+++ b/SRC/Lnt.hs
@@ -1,0 +1,36 @@
+------------------------------------------------------------------------------
+-----                                                                    -----
+-----     Lnt: Linting Syrup                                             -----
+-----                                                                    -----
+------------------------------------------------------------------------------
+
+{-# LANGUAGE LambdaCase #-}
+
+module Syrup.SRC.Lnt where
+
+import Syrup.SRC.Syn
+
+class Lint t where
+  lint :: t -> Maybe [String]
+  lint _ = Nothing
+
+instance Lint Def where
+  lint = \case
+    Def (fun, _) _ (Just []) -> Just $
+      [ "Warning: empty where clause in the definition of " ++ fun ++ "."
+      , "Did you forget to indent the block of local definitions using spaces?"
+      ]
+    _ -> Nothing
+
+instance Lint (Source' a) where
+  lint = \case
+    Definition d -> lint d
+    _ -> Nothing
+
+linter :: Lint t
+       => [Either [String] (t, String)]
+       -> [Either [String] (t, String)]
+linter xs = xs >>= \case
+  err@Left{}         -> [err]
+  src@(Right (t, _)) -> maybe id ((:) . Left) (lint t) [src]
+

--- a/SRC/Par.hs
+++ b/SRC/Par.hs
@@ -276,11 +276,10 @@ pMore prec e = ( pSpc *> (
      <*> (((e:) . (:[])) <$> pExpPrec 2) >>= pMore prec)
   ) ) <|> pure e
 
-
-pEqns :: Par [Eqn]
+pEqns :: Par (Maybe [Eqn])
 pEqns =
-  id <$ pTokIs (Id "where") <* pSpc <*> pAll pEqn
-  <|> [] <$ pEOI
+  Just <$ pTokIs (Id "where") <* pSpc <*> pAll pEqn
+  <|> Nothing <$ pEOI
 
 pEqn :: Par Eqn
 pEqn = pClue (SEEKING "an equation") $

--- a/SRC/Scp.hs
+++ b/SRC/Scp.hs
@@ -163,6 +163,7 @@ isGlobalVar ga nm = do
 
 type family Level t :: ScopeLevel where
   Level [a]         = Level a
+  Level (Maybe a)   = Level a
   Level Pat         = 'Local
   Level Eqn         = 'Local
   Level (DEC' a)    = 'Global
@@ -186,6 +187,8 @@ class Scoped t where
   scopecheck ga ts = do
     es <- mapM (scopecheck ga) ts
     foldM mergeExtension emptyExtension es
+
+instance Scoped a => Scoped (Maybe a)
 
 instance Scoped Pat where
   scopecheck ga = \case

--- a/SRC/Syn.hs
+++ b/SRC/Syn.hs
@@ -43,7 +43,7 @@ data Eqn = [Pat] :=: [Exp]
 data Def
   = Stub String [String]
   -- stubbed out definition together with error msg
-  | Def (String,[Pat]) [Exp] [Eqn]
+  | Def (String,[Pat]) [Exp] (Maybe [Eqn])
   deriving Show
 
 data TY' a

--- a/SRC/Utils.hs
+++ b/SRC/Utils.hs
@@ -1,0 +1,24 @@
+------------------------------------------------------------------------------
+-----                                                                    -----
+-----     Utils: Syrup Utility functions                                 -----
+-----                                                                    -----
+------------------------------------------------------------------------------
+
+{-# LANGUAGE LambdaCase #-}
+
+module Syrup.SRC.Utils where
+
+import Control.Arrow
+
+spanMaybe :: (a -> Maybe b) -> [a] -> ([b], [a])
+spanMaybe p = go where
+
+  go []             = ([], [])
+  go aas@(a : as)
+    | Just b <- p a = ((b :) *** id) (go as)
+    | otherwise     = ([], aas)
+
+isLeft :: Either a b -> Maybe a
+isLeft = \case
+  Left a -> Just a
+  _      -> Nothing

--- a/SRC/linter.out
+++ b/SRC/linter.out
@@ -1,0 +1,22 @@
+Warning: empty where clause in the definition of and.
+Did you forget to indent the block of local definitions using spaces?
+
+I was trying to make sense of the following code:
+
+and(<Bit>,<Bit>) -> <Bit>
+and(X,Y) = notnand where
+
+
+Error: You tried to use notnand but it is not in scope.
+
+and has been stubbed out.
+
+I was trying to make sense of the following code:
+
+notnand = nand(nand(X,Y),nand(X,Y))
+
+I got stuck here: 
+  ... notnand  {HERE} = nand(nand(X,Y),nand(X,Y))  ...
+I was looking for a component template.
+At that point, I was hoping for (..) but I found = which vexed me.
+

--- a/SRC/linter.syrup
+++ b/SRC/linter.syrup
@@ -1,0 +1,4 @@
+and(<Bit>,<Bit>) -> <Bit>
+and(X,Y) = notnand where
+
+notnand = nand(nand(X,Y),nand(X,Y))


### PR DESCRIPTION
Whenever students use a "where" keyword but there are no attached
definitions, it is a good sign they probably forgot to indent the
block. So we should warn them that there is an issue.
